### PR TITLE
Removing <#noparse> tags from HTML for form.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,12 +194,12 @@ Now you build the "main" page.
 ```html
 <html>
 	<body>
-		<form action="#" th:action="@{/}" th:object="<#noparse>$</#noparse>{person}" method="post">
+		<form action="#" th:action="@{/}" th:object="${person}" method="post">
 			<table>
 				<tr>
 					<td>How old are you?</td>
 					<td><input type="text" th:field="*{age}" /></td>
-					<td><div id="errors" th:text="<#noparse>$</#noparse>{error}" /></td>
+					<td><div id="errors" th:text="${error}" /></td>
 				</tr>
 				<tr>
 					<td><button type="submit">Submit</button></td>


### PR DESCRIPTION
Hi Greg - 

Thanks for all these guides.  It looks like the version of the code that's copyable from the spring.io site contains the <#noparse> tags for Tiles and this causes the application to run improperly when built according to the steps in the guide.

I hope this is the appropriate fix.
