### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.writing.txt
+++ b/LICENSE.writing.txt
@@ -1,1 +1,1 @@
-Except where otherwise noted, this work is licensed under http://creativecommons.org/licenses/by-nd/3.0/
+Except where otherwise noted, this work is licensed under https://creativecommons.org/licenses/by-nd/3.0/

--- a/README.adoc
+++ b/README.adoc
@@ -89,7 +89,7 @@ NOTE: In this simple example, these web pages don't have any sophisticated CSS o
 
 
 == Create an Application class
-For this application, you are using the template language of http://www.thymeleaf.org/doc/tutorials/3.0/thymeleafspring.html[Thymeleaf]. This application needs more than raw HTML.
+For this application, you are using the template language of https://www.thymeleaf.org/doc/tutorials/3.0/thymeleafspring.html[Thymeleaf]. This application needs more than raw HTML.
 
 `src/main/java/hello/Application.java`
 [source,java]


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://creativecommons.org/licenses/by-nd/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by-nd/3.0/ ([https](https://creativecommons.org/licenses/by-nd/3.0/) result 200).
* [ ] http://www.thymeleaf.org/doc/tutorials/3.0/thymeleafspring.html with 1 occurrences migrated to:  
  https://www.thymeleaf.org/doc/tutorials/3.0/thymeleafspring.html ([https](https://www.thymeleaf.org/doc/tutorials/3.0/thymeleafspring.html) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080/ with 1 occurrences